### PR TITLE
Add Job Sample config for Profile jobs

### DIFF
--- a/aws-databrew-dataset/pom.xml
+++ b/aws-databrew-dataset/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.75</version>
+            <version>2.15.80</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-job/aws-databrew-job.json
+++ b/aws-databrew-job/aws-databrew-job.json
@@ -112,6 +112,18 @@
     "Timeout": {
       "description": "Timeout",
       "type": "integer"
+    },
+    "JobSample": {
+      "description": "Job Sample",
+      "type": "object",
+      "properties": {
+        "Mode": {
+          "$ref": "#/definitions/SampleMode"
+        },
+        "Size": {
+          "$ref": "#/definitions/JobSize"
+        }
+      }
     }
   },
   "definitions": {
@@ -224,6 +236,19 @@
         "Value",
         "Key"
       ]
+    },
+    "SampleMode": {
+      "description": "Sample configuration mode for profile jobs.",
+      "enum": [
+        "FULL_DATASET",
+        "CUSTOM_ROWS"
+      ],
+      "type": "string"
+    },
+    "JobSize": {
+      "description": "Sample configuration size for profile jobs.",
+      "format": "int64",
+      "type": "integer"
     }
   },
   "additionalProperties": false,

--- a/aws-databrew-job/pom.xml
+++ b/aws-databrew-job/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.75</version>
+            <version>2.15.80</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.3</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-databrew-job/src/main/java/software/amazon/databrew/job/CreateHandler.java
+++ b/aws-databrew-job/src/main/java/software/amazon/databrew/job/CreateHandler.java
@@ -30,13 +30,16 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
 
         final String jobName = model.getName();
         final String jobType = model.getType();
+        final JobSample jobSample = model.getJobSample();
 
-        if ((!jobType.equals(ModelHelper.Type.PROFILE.toString())) && (!jobType.equals(ModelHelper.Type.RECIPE.toString()))) {
+        if (((!jobType.equals(ModelHelper.Type.PROFILE.toString())) && (!jobType.equals(ModelHelper.Type.RECIPE.toString()))) ||
+            jobType.equals(ModelHelper.Type.RECIPE.toString()) && jobSample != null) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
                     .errorCode(HandlerErrorCode.InvalidRequest)
                     .status(OperationStatus.FAILED)
                     .build();
         }
+
 
         if (jobType.equals(ModelHelper.Type.RECIPE.toString())) {
             final CreateRecipeJobRequest createRecipeJobRequest = CreateRecipeJobRequest.builder()
@@ -86,6 +89,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                     .roleArn(model.getRoleArn())
                     .tags(ModelHelper.buildTagInputMap(model.getTags()))
                     .timeout(model.getTimeout())
+                    .jobSample(ModelHelper.buildModelJobSample(model.getJobSample()))
                     .build();
 
             try {

--- a/aws-databrew-job/src/main/java/software/amazon/databrew/job/ModelHelper.java
+++ b/aws-databrew-job/src/main/java/software/amazon/databrew/job/ModelHelper.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.databrew.model.Output;
 import software.amazon.awssdk.services.databrew.model.RecipeReference;
 import software.amazon.awssdk.services.databrew.model.OutputFormatOptions;
 import software.amazon.awssdk.services.databrew.model.CsvOutputOptions;
+import software.amazon.awssdk.services.databrew.model.SampleMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,8 +38,10 @@ public class ModelHelper {
                 .build();
         if (job.typeAsString().equals(Type.RECIPE.toString()))
             model.setOutputs(buildModelOutputs(job.outputs()));
-        else if (job.typeAsString().equals(Type.PROFILE.toString()))
+        else if (job.typeAsString().equals(Type.PROFILE.toString())) {
             model.setOutputLocation(buildModelOutputLocation(job.outputs()));
+            model.setJobSample(buildRequestJobSample(job.jobSample()));
+        }
 
         return model;
     }
@@ -59,12 +62,44 @@ public class ModelHelper {
                 .tags(tags != null ? buildModelTags(tags) : null)
                 .timeout(job.timeout())
                 .build();
-        if (job.type().equals(Type.RECIPE.toString()))
+        if (job.typeAsString().equals(Type.RECIPE.toString()))
             model.setOutputs(buildModelOutputs(job.outputs()));
-        else if (job.type().equals(Type.PROFILE.toString()))
+        else if (job.typeAsString().equals(Type.PROFILE.toString())) {
             model.setOutputLocation(buildModelOutputLocation(job.outputs()));
+            model.setJobSample(buildRequestJobSample(job.jobSample()));
+        }
 
         return model;
+    }
+
+    public static JobSample buildRequestJobSample(final software.amazon.awssdk.services.databrew.model.JobSample jobSample) {
+        if (jobSample == null) {
+            return null;
+        } else if (jobSample.mode().equals(SampleMode.FULL_DATASET)) {
+            return JobSample.builder()
+                    .mode(jobSample.modeAsString())
+                    .build();
+        } else {
+            return JobSample.builder()
+                    .mode(jobSample.modeAsString())
+                    .size(jobSample.size())
+                    .build();
+        }
+    }
+
+    public static software.amazon.awssdk.services.databrew.model.JobSample buildModelJobSample(final JobSample jobSample) {
+        if (jobSample == null) {
+            return null;
+        } else if (jobSample.getMode().equals(SampleMode.FULL_DATASET)) {
+            return software.amazon.awssdk.services.databrew.model.JobSample.builder()
+                    .mode(jobSample.getMode())
+                    .build();
+        } else {
+            return software.amazon.awssdk.services.databrew.model.JobSample.builder()
+                    .mode(jobSample.getMode())
+                    .size(jobSample.getSize())
+                    .build();
+        }
     }
 
     public static S3Location buildRequestS3Location(final software.amazon.databrew.job.S3Location modelS3Location) {

--- a/aws-databrew-job/src/main/java/software/amazon/databrew/job/UpdateHandler.java
+++ b/aws-databrew-job/src/main/java/software/amazon/databrew/job/UpdateHandler.java
@@ -28,8 +28,10 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
         final String jobName = model.getName();
         final String jobType = model.getType();
+        final JobSample jobSample = model.getJobSample();
 
-        if ((!jobType.equals(ModelHelper.Type.PROFILE.toString())) && (!jobType.equals(ModelHelper.Type.RECIPE.toString()))) {
+        if (((!jobType.equals(ModelHelper.Type.PROFILE.toString())) && (!jobType.equals(ModelHelper.Type.RECIPE.toString()))) ||
+            jobType.equals(ModelHelper.Type.RECIPE.toString()) && jobSample != null) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
                     .errorCode(HandlerErrorCode.InvalidRequest)
                     .status(OperationStatus.FAILED)
@@ -78,6 +80,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .outputLocation(ModelHelper.buildRequestS3Location(model.getOutputLocation()))
                     .roleArn(model.getRoleArn())
                     .timeout(model.getTimeout())
+                    .jobSample(ModelHelper.buildModelJobSample(model.getJobSample()))
                     .build();
 
             try {

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/CreateHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/CreateHandlerTest.java
@@ -182,6 +182,181 @@ public class CreateHandlerTest {
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
     }
 
+    @Test
+    public void handleRequest_WithFullDatasetMode_SimpleSuccess_ProfileJob() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateProfileJobResponse createProfileJobResponse = CreateProfileJobResponse.builder().build();
+        doReturn(createProfileJobResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_PROFILE)
+                .name(JOB_NAME)
+                .tags(ModelHelper.buildModelTags(TestUtil.sampleTags()))
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.fullDatasetModeJobSample()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_WithCustomRowsMode_SimpleSuccess_ProfileJob() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateProfileJobResponse createProfileJobResponse = CreateProfileJobResponse.builder().build();
+        doReturn(createProfileJobResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_PROFILE)
+                .name(JOB_NAME)
+                .tags(ModelHelper.buildModelTags(TestUtil.sampleTags()))
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.customRowsModeJobSample()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample1_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_PROFILE)
+                .name(JOB_NAME)
+                .tags(ModelHelper.buildModelTags(TestUtil.sampleTags()))
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample1()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample2_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_PROFILE)
+                .name(JOB_NAME)
+                .tags(ModelHelper.buildModelTags(TestUtil.sampleTags()))
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample2()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample3_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_PROFILE)
+                .name(JOB_NAME)
+                .tags(ModelHelper.buildModelTags(TestUtil.sampleTags()))
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample3()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample4_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_PROFILE)
+                .name(JOB_NAME)
+                .tags(ModelHelper.buildModelTags(TestUtil.sampleTags()))
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample4()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
 
     @Test
     public void handleRequest_SimpleSuccess_RecipeJob() {

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/ListHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/ListHandlerTest.java
@@ -50,15 +50,24 @@ public class ListHandlerTest {
         Job job1 = Job.builder()
                 .type(TestUtil.JOB_TYPE_PROFILE)
                 .name("job1")
+                .jobSample(TestUtil.fullDatasetModeJobSample())
                 .outputs(TestUtil.OUTPUTS)
                 .build();
         Job job2 = Job.builder()
+                .type(TestUtil.JOB_TYPE_PROFILE)
+                .name("job2")
+                .jobSample(TestUtil.customRowsModeJobSample())
+                .outputs(TestUtil.OUTPUTS)
+                .build();
+        // When job sample is empty then it defaults to Mode : CUSTOM_ROWS and Size : 20000
+        Job job3 = Job.builder()
                 .type(TestUtil.JOB_TYPE_PROFILE)
                 .name("job2")
                 .outputs(TestUtil.OUTPUTS)
                 .build();
         jobs.add(job1);
         jobs.add(job2);
+        jobs.add(job3);
 
         final ListJobsResponse listJobsResponse = ListJobsResponse.builder()
                 .jobs(jobs)
@@ -82,11 +91,12 @@ public class ListHandlerTest {
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNull();
-        assertThat(response.getResourceModels().size()).isEqualTo(2);
+        assertThat(response.getResourceModels().size()).isEqualTo(3);
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
         assertThatJobModelsAreEqual(response.getResourceModels().get(0), job1);
         assertThatJobModelsAreEqual(response.getResourceModels().get(1), job2);
+        assertThatJobModelsAreEqual(response.getResourceModels().get(2), job2);
     }
 
     @Test

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/ReadHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/ReadHandlerTest.java
@@ -46,12 +46,14 @@ public class ReadHandlerTest {
                 .type(TestUtil.JOB_TYPE_PROFILE)
                 .name(TestUtil.JOB_NAME)
                 .outputs(TestUtil.OUTPUTS)
+                .jobSample(TestUtil.customRowsModeJobSample())
                 .timeout(TestUtil.TIMEOUT)
                 .build();
 
         final DescribeJobResponse describeJobResponse = DescribeJobResponse.builder()
                 .type(job.type())
                 .name(job.name())
+                .jobSample(job.jobSample())
                 .outputs(TestUtil.OUTPUTS)
                 .timeout(job.timeout())
                 .build();

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/TestUtil.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/TestUtil.java
@@ -4,7 +4,9 @@ import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.services.databrew.model.CsvOutputOptions;
 import software.amazon.awssdk.services.databrew.model.Job;
 import software.amazon.awssdk.services.databrew.model.OutputFormatOptions;
+import software.amazon.awssdk.services.databrew.model.SampleMode;
 import software.amazon.awssdk.services.databrew.model.S3Location;
+import software.amazon.awssdk.services.databrew.model.JobSample;
 import software.amazon.awssdk.services.databrew.model.Output;
 
 import java.util.HashMap;
@@ -24,6 +26,7 @@ public class TestUtil {
     public static final Integer UPDATED_TIMEOUT = 2880;
     public static final String PIPE_CSV_DELIMITER = "|";
     public static final String INVALID_CSV_DELIMITER = "*";
+
     public static final S3Location S3_LOCATION = S3Location.builder()
             .bucket(S3_BUCKET)
             .build();
@@ -50,6 +53,47 @@ public class TestUtil {
         tagMap.put("test1Key", "test1Value");
         tagMap.put("test2Key", "test12Value");
         return tagMap;
+    }
+    public static JobSample fullDatasetModeJobSample() {
+        return JobSample.builder()
+                .mode(SampleMode.FULL_DATASET.toString())
+                .build();
+    }
+    public static JobSample customRowsModeJobSample() {
+        return JobSample.builder()
+                .mode(SampleMode.CUSTOM_ROWS.toString())
+                .size(Long.valueOf(500))
+                .build();
+    }
+    public static JobSample defaultCustomRowsModeJobSample() {
+        return JobSample.builder()
+                .mode(SampleMode.CUSTOM_ROWS.toString())
+                .size(Long.valueOf(20000))
+                .build();
+    }
+    public static JobSample invalidJobSample1() {
+        return JobSample.builder()
+                .mode(SampleMode.CUSTOM_ROWS.toString())
+                .size(Long.valueOf(Long.MAX_VALUE + 1))
+                .build();
+    }
+    public static JobSample invalidJobSample2() {
+        return JobSample.builder()
+                .mode("")
+                .size(Long.valueOf(Long.MAX_VALUE))
+                .build();
+    }
+    public static JobSample invalidJobSample3() {
+        return JobSample.builder()
+                .mode(SampleMode.CUSTOM_ROWS.toString())
+                .size(Long.valueOf(-500))
+                .build();
+    }
+    public static JobSample invalidJobSample4() {
+        return JobSample.builder()
+                .mode(SampleMode.FULL_DATASET.toString())
+                .size(Long.valueOf(500))
+                .build();
     }
     public static void assertThatJobModelsAreEqual(final Object rawModel,
                                                 final Job sdkModel) {

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/UpdateHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/UpdateHandlerTest.java
@@ -73,6 +73,182 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    public void handleRequest_WithFullDatasetMode_SimpleSuccess_ProfileJob() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateProfileJobResponse updateProfileJobResponse = UpdateProfileJobResponse.builder().build();
+        doReturn(updateProfileJobResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .type(TestUtil.JOB_TYPE_PROFILE)
+                .name(TestUtil.JOB_NAME)
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.fullDatasetModeJobSample()))
+                .timeout(TestUtil.TIMEOUT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_WithCustomRowsMode_SimpleSuccess_ProfileJob() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateProfileJobResponse updateProfileJobResponse = UpdateProfileJobResponse.builder().build();
+        doReturn(updateProfileJobResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .type(TestUtil.JOB_TYPE_PROFILE)
+                .name(TestUtil.JOB_NAME)
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.customRowsModeJobSample()))
+                .timeout(TestUtil.TIMEOUT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample1_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(TestUtil.JOB_TYPE_PROFILE)
+                .name(TestUtil.JOB_NAME)
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample1()))
+                .timeout(TestUtil.UPDATED_TIMEOUT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample2_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(TestUtil.JOB_TYPE_PROFILE)
+                .name(TestUtil.JOB_NAME)
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample2()))
+                .timeout(TestUtil.UPDATED_TIMEOUT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample3_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(TestUtil.JOB_TYPE_PROFILE)
+                .name(TestUtil.JOB_NAME)
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample3()))
+                .timeout(TestUtil.UPDATED_TIMEOUT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_WithInvalidJobSample4_CreateFailed_ProfileJob() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .type(TestUtil.JOB_TYPE_PROFILE)
+                .name(TestUtil.JOB_NAME)
+                .jobSample(ModelHelper.buildRequestJobSample(TestUtil.invalidJobSample4()))
+                .timeout(TestUtil.UPDATED_TIMEOUT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
     public void handleRequest_FailedCreate_AmazonElixirException() {
         doThrow(DataBrewException.class)
                 .when(proxy)

--- a/aws-databrew-project/pom.xml
+++ b/aws-databrew-project/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.75</version>
+            <version>2.15.80</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-recipe/pom.xml
+++ b/aws-databrew-recipe/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.75</version>
+            <version>2.15.80</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-schedule/pom.xml
+++ b/aws-databrew-schedule/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.75</version>
+            <version>2.15.80</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A sample configuration for profile jobs only, which determines the number of rows on which the profile job is run. If a JobSample value isn't provided, the default is used. The default value is CUSTOM_ROWS for the mode parameter and 20,000 for the size parameter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
