### PR TITLE
Header-less and extension-less support for dataset.

### DIFF
--- a/aws-databrew-dataset/aws-databrew-dataset.json
+++ b/aws-databrew-dataset/aws-databrew-dataset.json
@@ -9,6 +9,16 @@
       "minLength": 1,
       "maxLength": 255
     },
+    "Format": {
+      "description": "Dataset format",
+      "enum": [
+        "CSV",
+        "JSON",
+        "PARQUET",
+        "EXCEL"
+      ],
+      "type": "string"
+    },
     "FormatOptions": {
       "description": "Format options for dataset",
       "type": "object",
@@ -23,6 +33,23 @@
           "$ref": "#/definitions/CsvOptions"
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "Json"
+          ]
+        },
+        {
+          "required": [
+            "Excel"
+          ]
+        },
+        {
+          "required": [
+            "Csv"
+          ]
+        }
+      ],
       "additionalProperties": false
     },
     "Input": {
@@ -87,6 +114,9 @@
           },
           "minItems": 1,
           "maxItems": 1
+        },
+        "HeaderRow": {
+          "type": "boolean"
         }
       },
       "oneOf": [
@@ -111,6 +141,9 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 1
+        },
+        "HeaderRow": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/aws-databrew-dataset/pom.xml
+++ b/aws-databrew-dataset/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.80</version>
+            <version>2.16.7</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/CreateHandler.java
+++ b/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/CreateHandler.java
@@ -31,6 +31,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final DataBrewClient databrewClient = ClientBuilder.getClient();
         final CreateDatasetRequest createDatasetRequest = CreateDatasetRequest.builder()
                 .name(datasetName)
+                .format(model.getFormat())
                 .formatOptions(ModelHelper.buildRequestFormatOptions(model.getFormatOptions()))
                 .input(ModelHelper.buildRequestInput(model.getInput()))
                 .tags(ModelHelper.buildTagInputMap(model.getTags()))

--- a/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/ModelHelper.java
+++ b/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/ModelHelper.java
@@ -19,6 +19,7 @@ public class ModelHelper {
         Map<String, String> tags = dataset.tags();
         return ResourceModel.builder()
                 .name(dataset.name())
+                .format(dataset.format() != null ? dataset.format().toString() : null)
                 .input(buildModelInput(dataset.input()))
                 .formatOptions(buildModelFormatOptions(dataset.formatOptions()))
                 .tags(tags != null ? buildModelTags(tags) : null)
@@ -29,6 +30,7 @@ public class ModelHelper {
         Map<String, String> tags = dataset.tags();
         return ResourceModel.builder()
                 .name(dataset.name())
+                .format(dataset.format() != null ? dataset.format().toString() : null)
                 .input(buildModelInput(dataset.input()))
                 .formatOptions(buildModelFormatOptions(dataset.formatOptions()))
                 .tags(tags != null ? buildModelTags(tags) : null)
@@ -92,12 +94,14 @@ public class ModelHelper {
             if (modelExcelOptions.getSheetIndexes() != null) {
                 software.amazon.awssdk.services.databrew.model.ExcelOptions requestExcelOptions = software.amazon.awssdk.services.databrew.model.ExcelOptions.builder()
                         .sheetIndexes(modelExcelOptions.getSheetIndexes())
+                        .headerRow(modelExcelOptions.getHeaderRow())
                         .build();
                 requestFormatOptionsBuilder
                         .excel(requestExcelOptions);
             } else if (modelExcelOptions.getSheetNames() != null) {
                 ExcelOptions requestExcelOptions = ExcelOptions.builder()
                         .sheetNames(modelExcelOptions.getSheetNames())
+                        .headerRow(modelExcelOptions.getHeaderRow())
                         .build();
                 requestFormatOptionsBuilder
                         .excel(requestExcelOptions);
@@ -113,6 +117,7 @@ public class ModelHelper {
         if (modelCsvOptions != null) {
             CsvOptions requestCsvOptions = CsvOptions.builder()
                     .delimiter(modelCsvOptions.getDelimiter())
+                    .headerRow(modelCsvOptions.getHeaderRow())
                     .build();
             requestFormatOptionsBuilder
                     .csv(requestCsvOptions);
@@ -148,20 +153,23 @@ public class ModelHelper {
                 modelFormatOptionsBuilder
                         .excel(modelExcelOptions.builder()
                                 .sheetIndexes(requestFormatOptions.excel().sheetIndexes())
+                                .headerRow(requestFormatOptions.excel().headerRow())
                                 .build());
             }
             else {
                 modelFormatOptionsBuilder.
                         excel(modelExcelOptions.builder()
                                 .sheetNames(requestFormatOptions.excel().sheetNames())
+                                .headerRow(requestFormatOptions.excel().headerRow())
                                 .build());
                 }
         }
         if (requestFormatOptions.csv() != null) {
             modelFormatOptionsBuilder
                     .csv(modelCsvOptions.builder()
-                                .delimiter(requestFormatOptions.csv().delimiter())
-                                .build());
+                            .delimiter(requestFormatOptions.csv().delimiter())
+                            .headerRow(requestFormatOptions.csv().headerRow())
+                            .build());
         }
         return modelFormatOptionsBuilder.build();
     }

--- a/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/UpdateHandler.java
+++ b/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/UpdateHandler.java
@@ -27,6 +27,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
         final UpdateDatasetRequest updateDatasetRequest = UpdateDatasetRequest.builder()
                 .name(datasetName)
+                .format(model.getFormat())
                 .formatOptions(ModelHelper.buildRequestFormatOptions(model.getFormatOptions()))
                 .input(ModelHelper.buildRequestInput(model.getInput()))
                 .build();

--- a/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/CreateHandlerTest.java
+++ b/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/CreateHandlerTest.java
@@ -268,4 +268,139 @@ public class CreateHandlerTest {
         assertThat(response.getErrorCode()).isNull();
     }
 
+    @Test
+    public void handleRequest_SuccessfulCreate_ValidFormatWithHeaderlessCsv() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateDatasetResponse createDatasetResponse = CreateDatasetResponse.builder().build();
+        doReturn(createDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.CSV_FORMAT)
+                .input(TestUtil.CSV_S3_INPUT)
+                .formatOptions(TestUtil.CSV_FORMAT_OPTIONS_HEADERLESS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getFormatOptions()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getCsv()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getCsv().getDelimiter()).isEqualTo(TestUtil.PIPE_CSV_DELIMITER);
+        assertThat(response.getResourceModel().getFormatOptions().getCsv().getHeaderRow()).isEqualTo(false);
+        assertThat(response.getResourceModel().getFormat()).isEqualTo(TestUtil.CSV_FORMAT);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_SuccessfulCreate_ValidFormatWithHeaderlessExcel() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateDatasetResponse createDatasetResponse = CreateDatasetResponse.builder().build();
+        doReturn(createDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.EXCEL_FORMAT)
+                .input(TestUtil.EXCEL_S3_INPUT)
+                .formatOptions(TestUtil.EXCEL_FORMAT_OPTIONS_HEADERLESS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getFormatOptions()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getExcel()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getExcel().getHeaderRow()).isEqualTo(false);
+        assertThat(response.getResourceModel().getFormat()).isEqualTo(TestUtil.EXCEL_FORMAT);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_SuccessfulCreate_ValidFormatWithExtensionlessJson() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateDatasetResponse createDatasetResponse = CreateDatasetResponse.builder().build();
+        doReturn(createDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.JSON_S3_INPUT_EXTENSIONLESS)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getFormatOptions()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getJson()).isNotNull();
+        assertThat(response.getResourceModel().getFormat()).isEqualTo(TestUtil.JSON_FORMAT);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedCreate_MismatchedParquetFormatAndJsonFormatOptions() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.PARQUET_FORMAT)
+                .input(TestUtil.JSON_S3_INPUT_EXTENSIONLESS)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
 }

--- a/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/TestUtil.java
+++ b/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/TestUtil.java
@@ -17,9 +17,15 @@ public class TestUtil {
     public static final String UPDATED_S3_KEY = "input.xlsx";
     public static final String CSV_S3_KEY = "input.csv";
     public static final String TSV_S3_KEY = "input.tsv";
+    public static final String EXCEL_S3_KEY = "input.xlsx";
+    public static final String JSON_S3_KEY_EXTENSIONLESS = "input";
     public static final String PIPE_CSV_DELIMITER = "|";
     public static final String TAB_CSV_DELIMITER = "\t";
     public static final String INVALID_CSV_DELIMITER = "*";
+    public static final String CSV_FORMAT = "CSV";
+    public static final String EXCEL_FORMAT = "EXCEL";
+    public static final String JSON_FORMAT = "JSON";
+    public static final String PARQUET_FORMAT = "PARQUET";
     public static final S3Location s3InputDefinition = S3Location.builder()
             .bucket(S3_BUCKET)
             .key(S3_KEY)
@@ -47,6 +53,20 @@ public class TestUtil {
             .build();
     public static final Input TSV_S3_INPUT = Input.builder()
             .s3InputDefinition(tsvS3InputDefinition)
+            .build();
+    public static final S3Location excelS3InputDefinition = S3Location.builder()
+            .bucket(S3_BUCKET)
+            .key(EXCEL_S3_KEY)
+            .build();
+    public static final Input EXCEL_S3_INPUT = Input.builder()
+            .s3InputDefinition(excelS3InputDefinition)
+            .build();
+    public static final S3Location jsonS3InputDefinition = S3Location.builder()
+            .bucket(S3_BUCKET)
+            .key(JSON_S3_KEY_EXTENSIONLESS)
+            .build();
+    public static final Input JSON_S3_INPUT_EXTENSIONLESS = Input.builder()
+            .s3InputDefinition(jsonS3InputDefinition)
             .build();
     public static final JsonOptions JSON_OPTIONS = JsonOptions.builder()
             .multiLine(true)
@@ -83,6 +103,20 @@ public class TestUtil {
             .build();
     public static final FormatOptions TSV_FORMAT_OPTIONS = FormatOptions.builder()
             .csv(TSV_OPTIONS)
+            .build();
+    public static final CsvOptions CSV_OPTIONS_HEADERLESS = CsvOptions.builder()
+            .delimiter(PIPE_CSV_DELIMITER)
+            .headerRow(false)
+            .build();
+    public static final FormatOptions CSV_FORMAT_OPTIONS_HEADERLESS = FormatOptions.builder()
+            .csv(CSV_OPTIONS_HEADERLESS)
+            .build();
+    public static final ExcelOptions EXCEL_OPTIONS_HEADERLESS = ExcelOptions.builder()
+            .sheetNames(new ArrayList<String>(){{ add("test"); }})
+            .headerRow(false)
+            .build();
+    public static final FormatOptions EXCEL_FORMAT_OPTIONS_HEADERLESS = FormatOptions.builder()
+            .excel(EXCEL_OPTIONS_HEADERLESS)
             .build();
     public static final Map<String, String> sampleTags() {
         Map<String, String> tagMap = new HashMap<>();

--- a/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/UpdateHandlerTest.java
+++ b/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/UpdateHandlerTest.java
@@ -268,4 +268,140 @@ public class UpdateHandlerTest {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }
+
+    @Test
+    public void handleRequest_SuccessfulUpdate_ValidFormatWithHeaderlessCsv() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateDatasetResponse updateDatasetResponse = UpdateDatasetResponse.builder().build();
+        doReturn(updateDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.CSV_FORMAT)
+                .input(TestUtil.CSV_S3_INPUT)
+                .formatOptions(TestUtil.CSV_FORMAT_OPTIONS_HEADERLESS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getFormatOptions()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getCsv()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getCsv().getDelimiter()).isEqualTo(TestUtil.PIPE_CSV_DELIMITER);
+        assertThat(response.getResourceModel().getFormatOptions().getCsv().getHeaderRow()).isEqualTo(false);
+        assertThat(response.getResourceModel().getFormat()).isEqualTo(TestUtil.CSV_FORMAT);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_SuccessfulUpdate_ValidFormatWithHeaderlessExcel() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateDatasetResponse updateDatasetResponse = UpdateDatasetResponse.builder().build();
+        doReturn(updateDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.EXCEL_FORMAT)
+                .input(TestUtil.EXCEL_S3_INPUT)
+                .formatOptions(TestUtil.EXCEL_FORMAT_OPTIONS_HEADERLESS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getFormatOptions()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getExcel()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getExcel().getHeaderRow()).isEqualTo(false);
+        assertThat(response.getResourceModel().getFormat()).isEqualTo(TestUtil.EXCEL_FORMAT);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_SuccessfulUpdate_ValidFormatWithExtensionlessJson() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateDatasetResponse updateDatasetResponse = UpdateDatasetResponse.builder().build();
+        doReturn(updateDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.JSON_S3_INPUT_EXTENSIONLESS)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getFormatOptions()).isNotNull();
+        assertThat(response.getResourceModel().getFormatOptions().getJson()).isNotNull();
+        assertThat(response.getResourceModel().getFormat()).isEqualTo(TestUtil.JSON_FORMAT);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedUpdate_MismatchedParquetFormatAndJsonFormatOptions() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.PARQUET_FORMAT)
+                .input(TestUtil.JSON_S3_INPUT_EXTENSIONLESS)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
 }

--- a/aws-databrew-job/pom.xml
+++ b/aws-databrew-job/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.80</version>
+            <version>2.16.7</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-project/pom.xml
+++ b/aws-databrew-project/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.80</version>
+            <version>2.16.7</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-recipe/pom.xml
+++ b/aws-databrew-recipe/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.80</version>
+            <version>2.16.7</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-schedule/pom.xml
+++ b/aws-databrew-schedule/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.15.80</version>
+            <version>2.16.7</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CloudFormation changes for supporting two new Dataset features - 1) Addition of Format field to Dataset for enabling extension-less files, and 2) Addition of HeaderRow attribute to CsvOptions and ExcelOptions for enabling users to specify if the first row contains a header for CSV and Excel file formats. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
