### PR TITLE
Support for dataset inputs based on database connections, and support…

### DIFF
--- a/aws-databrew-dataset/aws-databrew-dataset.json
+++ b/aws-databrew-dataset/aws-databrew-dataset.json
@@ -21,61 +21,15 @@
     },
     "FormatOptions": {
       "description": "Format options for dataset",
-      "type": "object",
-      "properties": {
-        "Json": {
-          "$ref": "#/definitions/JsonOptions"
-        },
-        "Excel": {
-          "$ref": "#/definitions/ExcelOptions"
-        },
-        "Csv": {
-          "$ref": "#/definitions/CsvOptions"
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "Json"
-          ]
-        },
-        {
-          "required": [
-            "Excel"
-          ]
-        },
-        {
-          "required": [
-            "Csv"
-          ]
-        }
-      ],
-      "additionalProperties": false
+      "$ref": "#/definitions/FormatOptions"
     },
     "Input": {
       "description": "Input",
-      "type": "object",
-      "properties": {
-        "S3InputDefinition": {
-          "$ref": "#/definitions/S3Location"
-        },
-        "DataCatalogInputDefinition": {
-          "$ref": "#/definitions/DataCatalogInputDefinition"
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "S3InputDefinition"
-          ]
-        },
-        {
-          "required": [
-            "DataCatalogInputDefinition"
-          ]
-        }
-      ],
-      "additionalProperties": false
+      "$ref": "#/definitions/Input"
+    },
+    "PathOptions": {
+      "description": "PathOptions",
+      "$ref": "#/definitions/PathOptions"
     },
     "Tags": {
       "type": "array",
@@ -148,6 +102,72 @@
       },
       "additionalProperties": false
     },
+    "FormatOptions": {
+      "description": "Format options for dataset",
+      "type": "object",
+      "properties": {
+        "Json": {
+          "$ref": "#/definitions/JsonOptions"
+        },
+        "Excel": {
+          "$ref": "#/definitions/ExcelOptions"
+        },
+        "Csv": {
+          "$ref": "#/definitions/CsvOptions"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "Json"
+          ]
+        },
+        {
+          "required": [
+            "Excel"
+          ]
+        },
+        {
+          "required": [
+            "Csv"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "Input": {
+      "description": "Input",
+      "type": "object",
+      "properties": {
+        "S3InputDefinition": {
+          "$ref": "#/definitions/S3Location"
+        },
+        "DataCatalogInputDefinition": {
+          "$ref": "#/definitions/DataCatalogInputDefinition"
+        },
+        "DatabaseInputDefinition": {
+          "$ref": "#/definitions/DatabaseInputDefinition"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "S3InputDefinition"
+          ]
+        },
+        {
+          "required": [
+            "DataCatalogInputDefinition"
+          ]
+        },
+        {
+          "required": [
+            "DatabaseInputDefinition"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
     "S3Location": {
       "description": "Input location",
       "type": "object",
@@ -184,6 +204,200 @@
         }
       },
       "additionalProperties": false
+    },
+    "DatabaseInputDefinition": {
+      "type": "object",
+      "properties": {
+        "GlueConnectionName": {
+          "description": "Glue connection name",
+          "type": "string"
+        },
+        "DatabaseTableName": {
+          "description": "Database table name",
+          "type": "string"
+        },
+        "TempDirectory": {
+          "$ref": "#/definitions/S3Location"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PathOptions": {
+      "description": "Path options for dataset",
+      "type": "object",
+      "properties": {
+        "FilesLimit": {
+          "$ref": "#/definitions/FilesLimit"
+        },
+        "LastModifiedDateCondition": {
+          "$ref": "#/definitions/FilterExpression"
+        },
+        "Parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PathParameter"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "FilesLimit": {
+      "type": "object",
+      "properties": {
+        "MaxFiles": {
+          "description": "Maximum number of files",
+          "type": "integer"
+        },
+        "OrderedBy": {
+          "description": "Ordered by",
+          "enum": [
+            "LAST_MODIFIED_DATE"
+          ],
+          "type": "string"
+        },
+        "Order": {
+          "description": "Order",
+          "enum": [
+            "ASCENDING",
+            "DESCENDING"
+          ],
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "MaxFiles"
+      ]
+    },
+    "PathParameter": {
+      "description": "A key-value pair to associate dataset parameter name with its definition.",
+      "type": "object",
+      "properties": {
+        "PathParameterName": {
+          "$ref": "#/definitions/PathParameterName"
+        },
+        "DatasetParameter": {
+          "$ref": "#/definitions/DatasetParameter"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "PathParameterName",
+        "DatasetParameter"
+      ]
+    },
+    "PathParameterName": {
+      "description": "Parameter name",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "DatasetParameter": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "$ref": "#/definitions/PathParameterName"
+        },
+        "Type": {
+          "description": "Parameter type",
+          "enum": [
+            "String",
+            "Number",
+            "Datetime"
+          ],
+          "type": "string"
+        },
+        "DatetimeOptions": {
+          "$ref": "#/definitions/DatetimeOptions"
+        },
+        "CreateColumn": {
+          "description": "Add the value of this parameter as a column in a dataset.",
+          "type": "boolean"
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterExpression"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Name",
+        "Type"
+      ]
+    },
+    "DatetimeOptions": {
+      "type": "object",
+      "properties": {
+        "Format": {
+          "description": "Date/time format of a date parameter",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 100
+        },
+        "TimezoneOffset": {
+          "description": "Timezone offset",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 6,
+          "pattern": "^(Z|[-+](\\d|\\d{2}|\\d{2}:?\\d{2}))$"
+        },
+        "LocaleCode": {
+          "description": "Locale code for a date parameter",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 100,
+          "pattern": "^[A-Za-z0-9_\\.#@\\-]+$"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Format"
+      ]
+    },
+    "FilterExpression": {
+      "type": "object",
+      "properties": {
+        "Expression": {
+          "description": "Filtering expression for a parameter",
+          "type": "string",
+          "minLength": 4,
+          "maxLength": 1024,
+          "pattern": "^[&lt;&gt;0-9A-Za-z_:)(!= ]+$"
+        },
+        "ValuesMap": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FilterValue"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Expression",
+        "ValuesMap"
+      ]
+    },
+    "FilterValue": {
+      "description": "A key-value pair to associate expression variable names with their values",
+      "type": "object",
+      "properties": {
+        "ValueReference": {
+          "description": "Variable name",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 128,
+          "pattern": "^:[A-Za-z0-9_]+$"
+        },
+        "Value": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 1024
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "ValueReference",
+        "Value"
+      ]
     },
     "Tag": {
       "description": "A key-value pair to associate with a resource.",
@@ -225,6 +439,8 @@
         "databrew:CreateDataset",
         "databrew:TagResource",
         "databrew:UntagResource",
+        "glue:GetConnection",
+        "glue:GetTable",
         "iam:PassRole"
       ]
     },
@@ -237,7 +453,9 @@
     },
     "update": {
       "permissions": [
-        "databrew:UpdateDataset"
+        "databrew:UpdateDataset",
+        "glue:GetConnection",
+        "glue:GetTable"
       ]
     },
     "delete": {

--- a/aws-databrew-dataset/pom.xml
+++ b/aws-databrew-dataset/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.7</version>
+            <version>2.16.31</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-dataset/resource-role.yaml
+++ b/aws-databrew-dataset/resource-role.yaml
@@ -31,6 +31,8 @@ Resources:
                 - "databrew:TagResource"
                 - "databrew:UntagResource"
                 - "databrew:UpdateDataset"
+                - "glue:GetConnection"
+                - "glue:GetTable"
                 - "iam:ListRoles"
                 - "iam:PassRole"
                 Resource: "*"

--- a/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/CreateHandler.java
+++ b/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/CreateHandler.java
@@ -33,8 +33,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .name(datasetName)
                 .format(model.getFormat())
                 .formatOptions(ModelHelper.buildRequestFormatOptions(model.getFormatOptions()))
+                .pathOptions(ModelHelper.buildRequestPathOptions(model.getPathOptions()))
                 .input(ModelHelper.buildRequestInput(model.getInput()))
-                .tags(ModelHelper.buildTagInputMap(model.getTags()))
+                .tags(ModelHelper.buildMapFromList(model.getTags(), tag -> tag.getKey(), tag -> tag.getValue()))
                 .build();
 
         try {

--- a/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/UpdateHandler.java
+++ b/aws-databrew-dataset/src/main/java/software/amazon/databrew/dataset/UpdateHandler.java
@@ -29,6 +29,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                 .name(datasetName)
                 .format(model.getFormat())
                 .formatOptions(ModelHelper.buildRequestFormatOptions(model.getFormatOptions()))
+                .pathOptions(ModelHelper.buildRequestPathOptions(model.getPathOptions()))
                 .input(ModelHelper.buildRequestInput(model.getInput()))
                 .build();
 

--- a/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/CreateHandlerTest.java
+++ b/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/CreateHandlerTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -403,4 +405,223 @@ public class CreateHandlerTest {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
     }
+
+    @Test
+    public void handleRequest_SuccessfulCreate_ValidFilesLimit() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateDatasetResponse createDatasetResponse = CreateDatasetResponse.builder().build();
+        doReturn(createDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.S3_FOLDER_INPUT)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_VALID_FILES_LIMIT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getPathOptions()).isNotNull();
+        assertThat(response.getResourceModel().getPathOptions().getFilesLimit()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedCreate_InvalidFilesLimit() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.S3_FOLDER_INPUT)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_INVALID_FILES_LIMIT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_SuccessfulCreate_ValidLastModified() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateDatasetResponse createDatasetResponse = CreateDatasetResponse.builder().build();
+        doReturn(createDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.S3_REGEX_INPUT)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_VALID_LAST_MODIFIED)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getPathOptions()).isNotNull();
+        assertThat(response.getResourceModel().getPathOptions().getLastModifiedDateCondition()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedCreate_InvalidLastModified() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.S3_REGEX_INPUT)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_INVALID_LAST_MODIFIED)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_SuccessfulCreate_ValidPathParam() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateDatasetResponse createDatasetResponse = CreateDatasetResponse.builder().build();
+        doReturn(createDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.S3_PARAM_INPUT)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_VALID_PARAM)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getPathOptions()).isNotNull();
+        assertThat(response.getResourceModel().getPathOptions().getParameters()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedCreate_InvalidPathParam() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final CreateHandler handler = new CreateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.S3_PARAM_INPUT)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_INVALID_PARAM)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+    @Test
+    public void handleRequest_SuccessfulCreate_DatabaseDataset() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateDatasetResponse createDatasetResponse = CreateDatasetResponse.builder().build();
+        doReturn(createDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        Map<String, String> tags = TestUtil.sampleTags();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.DATABASE_INPUT)
+                .tags(ModelHelper.buildModelTags(tags))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getResourceModel().getTags()).isNotNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
 }

--- a/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/ReadHandlerTest.java
+++ b/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/ReadHandlerTest.java
@@ -46,6 +46,8 @@ public class ReadHandlerTest {
         Dataset dataset = Dataset.builder()
                 .name(TestUtil.DATASET_NAME)
                 .formatOptions(ModelHelper.buildRequestFormatOptions(TestUtil.JSON_FORMAT_OPTIONS))
+                .pathOptions(ModelHelper.buildRequestPathOptions(TestUtil.PATH_OPTIONS_WITH_VALID_PARAM))
+                .tags(TestUtil.sampleTags())
                 .build();
 
         final DescribeDatasetResponse describeResult = DescribeDatasetResponse.builder()

--- a/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/UpdateHandlerTest.java
+++ b/aws-databrew-dataset/src/test/java/software/amazon/databrew/dataset/UpdateHandlerTest.java
@@ -1,5 +1,6 @@
 package software.amazon.databrew.dataset;
 
+import software.amazon.awssdk.services.databrew.model.CreateDatasetResponse;
 import software.amazon.awssdk.services.databrew.model.DataBrewException;
 import software.amazon.awssdk.services.databrew.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.databrew.model.UpdateDatasetResponse;
@@ -403,5 +404,224 @@ public class UpdateHandlerTest {
         assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_SuccessfulUpdate_ValidFilesLimit() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateDatasetResponse updateDatasetResponse = UpdateDatasetResponse.builder().build();
+        doReturn(updateDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.S3_FOLDER_INPUT)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_VALID_FILES_LIMIT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getPathOptions()).isNotNull();
+        assertThat(response.getResourceModel().getPathOptions().getFilesLimit()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedUpdate_InvalidFilesLimit() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.S3_FOLDER_INPUT)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_INVALID_FILES_LIMIT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_SuccessfulUpdate_ValidLastModified() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateDatasetResponse updateDatasetResponse = UpdateDatasetResponse.builder().build();
+        doReturn(updateDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.S3_REGEX_INPUT)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_VALID_LAST_MODIFIED)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getPathOptions()).isNotNull();
+        assertThat(response.getResourceModel().getPathOptions().getLastModifiedDateCondition()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedUpdate_InvalidLastModified() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.S3_REGEX_INPUT)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_INVALID_LAST_MODIFIED)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_SuccessfulUpdate_ValidPathParam() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateDatasetResponse updateDatasetResponse = UpdateDatasetResponse.builder().build();
+        doReturn(updateDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .format(TestUtil.JSON_FORMAT)
+                .input(TestUtil.S3_PARAM_INPUT)
+                .formatOptions(TestUtil.JSON_FORMAT_OPTIONS)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_VALID_PARAM)
+                .tags(ModelHelper.buildModelTags(TestUtil.sampleTags()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getPathOptions()).isNotNull();
+        assertThat(response.getResourceModel().getPathOptions().getParameters()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_FailedUpdate_InvalidPathParam() {
+        doThrow(ValidationException.class)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final UpdateHandler handler = new UpdateHandler();
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.S3_PARAM_INPUT)
+                .pathOptions(TestUtil.PATH_OPTIONS_WITH_INVALID_PARAM)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_SuccessfulUpdate_DatabaseInputDefinition() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateDatasetResponse updateDatasetResponse = UpdateDatasetResponse.builder().build();
+        doReturn(updateDatasetResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .name(TestUtil.DATASET_NAME)
+                .input(TestUtil.UPDATED_DATABASE_INPUT)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getInput()).isNotNull();
+        assertThat(response.getResourceModel().getInput().getDatabaseInputDefinition()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
     }
 }

--- a/aws-databrew-job/aws-databrew-job.json
+++ b/aws-databrew-job/aws-databrew-job.json
@@ -61,19 +61,7 @@
     },
     "OutputLocation": {
       "description": "Output location",
-      "type": "object",
-      "properties": {
-        "Bucket": {
-          "type": "string"
-        },
-        "Key": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "Bucket"
-      ]
+      "$ref": "#/definitions/OutputLocation"
     },
     "ProjectName": {
       "description": "Project name",
@@ -83,20 +71,7 @@
     },
     "Recipe": {
       "type": "object",
-      "properties": {
-        "Name": {
-          "description": "Recipe name",
-          "type": "string"
-        },
-        "Version": {
-          "description": "Recipe version",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "Name"
-      ]
+      "$ref": "#/definitions/Recipe"
     },
     "RoleArn": {
       "description": "Role arn",
@@ -115,15 +90,7 @@
     },
     "JobSample": {
       "description": "Job Sample",
-      "type": "object",
-      "properties": {
-        "Mode": {
-          "$ref": "#/definitions/SampleMode"
-        },
-        "Size": {
-          "$ref": "#/definitions/JobSize"
-        }
-      }
+      "$ref": "#/definitions/JobSample"
     }
   },
   "definitions": {
@@ -164,6 +131,22 @@
         }
       },
       "additionalProperties": false
+    },
+    "OutputLocation": {
+      "description": "Output location",
+      "type": "object",
+      "properties": {
+        "Bucket": {
+          "type": "string"
+        },
+        "Key": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Bucket"
+      ]
     },
     "Output": {
       "type": "object",
@@ -216,6 +199,23 @@
         "Location"
       ]
     },
+    "Recipe": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "Recipe name",
+          "type": "string"
+        },
+        "Version": {
+          "description": "Recipe version",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Name"
+      ]
+    },
     "Tag": {
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
@@ -249,6 +249,19 @@
       "description": "Sample configuration size for profile jobs.",
       "format": "int64",
       "type": "integer"
+    },
+    "JobSample": {
+      "description": "Job Sample",
+      "type": "object",
+      "properties": {
+        "Mode": {
+          "$ref": "#/definitions/SampleMode"
+        },
+        "Size": {
+          "$ref": "#/definitions/JobSize"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false,

--- a/aws-databrew-job/pom.xml
+++ b/aws-databrew-job/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.7</version>
+            <version>2.16.31</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.3</version>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-databrew-project/aws-databrew-project.json
+++ b/aws-databrew-project/aws-databrew-project.json
@@ -26,6 +26,19 @@
       "type": "string"
     },
     "Sample": {
+      "description": "Sample",
+      "$ref": "#/definitions/Sample"
+    },
+    "Tags": {
+      "type": "array",
+      "uniqueItems": false,
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
+    }
+  },
+  "definitions": {
+    "Sample": {
       "type": "object",
       "properties": {
         "Size": {
@@ -48,15 +61,6 @@
         "Type"
       ]
     },
-    "Tags": {
-      "type": "array",
-      "uniqueItems": false,
-      "items": {
-        "$ref": "#/definitions/Tag"
-      }
-    }
-  },
-  "definitions": {
     "Tag": {
       "description": "A key-value pair to associate with a resource.",
       "type": "object",

--- a/aws-databrew-project/pom.xml
+++ b/aws-databrew-project/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.7</version>
+            <version>2.16.31</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-recipe/pom.xml
+++ b/aws-databrew-recipe/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.7</version>
+            <version>2.16.31</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-schedule/pom.xml
+++ b/aws-databrew-schedule/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.7</version>
+            <version>2.16.31</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
… for dynamic datasets


*Description of changes:*
This change adds CloudFormation support for two new dataset features: 1) support for specifying a database connection as a dataset input 2) support for dynamic datasets that accept configurable parameters in S3 path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
