### PR TITLE
Adds support for the output of job results to the AWS Glue Data Catalog.

### DIFF
--- a/aws-databrew-dataset/pom.xml
+++ b/aws-databrew-dataset/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.31</version>
+            <version>2.16.93</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-job/aws-databrew-job.json
+++ b/aws-databrew-job/aws-databrew-job.json
@@ -59,6 +59,12 @@
         "$ref": "#/definitions/Output"
       }
     },
+    "DataCatalogOutputs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DataCatalogOutput"
+      }
+    },
     "OutputLocation": {
       "description": "Output location",
       "$ref": "#/definitions/OutputLocation"
@@ -198,6 +204,62 @@
       "required": [
         "Location"
       ]
+    },
+    "DataCatalogOutput": {
+      "type": "object",
+      "properties": {
+        "CatalogId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "DatabaseName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "TableName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "S3Options": {
+          "$ref": "#/definitions/S3TableOutputOptions"
+        },
+        "DatabaseOptions": {
+          "$ref": "#/definitions/DatabaseTableOutputOptions"
+        },
+        "Overwrite": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["DatabaseName", "TableName"]
+    },
+    "S3TableOutputOptions": {
+      "type": "object",
+      "properties": {
+        "Location": {
+          "$ref": "#/definitions/S3Location"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["Location"]
+    },
+    "DatabaseTableOutputOptions": {
+      "type": "object",
+      "properties": {
+        "TempDirectory": {
+          "$ref": "#/definitions/S3Location"
+        },
+        "TableName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      },
+      "additionalProperties": false,
+      "required": ["TableName"]
     },
     "Recipe": {
       "type": "object",

--- a/aws-databrew-job/aws-databrew-job.json
+++ b/aws-databrew-job/aws-databrew-job.json
@@ -234,7 +234,10 @@
         }
       },
       "additionalProperties": false,
-      "required": ["DatabaseName", "TableName"]
+      "required": [
+        "DatabaseName",
+        "TableName"
+      ]
     },
     "S3TableOutputOptions": {
       "type": "object",
@@ -244,7 +247,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["Location"]
+      "required": [
+        "Location"
+      ]
     },
     "DatabaseTableOutputOptions": {
       "type": "object",
@@ -259,7 +264,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["TableName"]
+      "required": [
+        "TableName"
+      ]
     },
     "Recipe": {
       "type": "object",

--- a/aws-databrew-job/pom.xml
+++ b/aws-databrew-job/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.31</version>
+            <version>2.16.93</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-databrew-job/src/main/java/software/amazon/databrew/job/CreateHandler.java
+++ b/aws-databrew-job/src/main/java/software/amazon/databrew/job/CreateHandler.java
@@ -51,6 +51,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                     .maxCapacity(model.getMaxCapacity())
                     .maxRetries(model.getMaxRetries())
                     .outputs(ModelHelper.buildRequestOutputs(model.getOutputs()))
+                    .dataCatalogOutputs(ModelHelper.buildRequestDataCatalogOutputs(model.getDataCatalogOutputs()))
                     .projectName(model.getProjectName())
                     .recipeReference(ModelHelper.buildRequestRecipe(model.getRecipe()))
                     .roleArn(model.getRoleArn())

--- a/aws-databrew-job/src/main/java/software/amazon/databrew/job/UpdateHandler.java
+++ b/aws-databrew-job/src/main/java/software/amazon/databrew/job/UpdateHandler.java
@@ -47,6 +47,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .maxCapacity(model.getMaxCapacity())
                     .maxRetries(model.getMaxRetries())
                     .outputs(ModelHelper.buildRequestOutputs(model.getOutputs()))
+                    .dataCatalogOutputs(ModelHelper.buildRequestDataCatalogOutputs(model.getDataCatalogOutputs()))
                     .roleArn(model.getRoleArn())
                     .timeout(model.getTimeout())
                     .build();

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/CreateHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/CreateHandlerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static software.amazon.databrew.job.TestUtil.DATA_CATALOG_OUTPUT_LIST;
 import static software.amazon.databrew.job.TestUtil.INVALID_JOB_NAME;
 import static software.amazon.databrew.job.TestUtil.JOB_NAME;
 import static software.amazon.databrew.job.TestUtil.JOB_TYPE_PROFILE;
@@ -553,6 +554,39 @@ public class CreateHandlerTest {
         assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_SuccessfulCreate_RecipeJob_ValidDataCatalogOutput() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateRecipeJobResponse createRecipeJobResponse = CreateRecipeJobResponse.builder().build();
+        doReturn(createRecipeJobResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_RECIPE)
+                .name(JOB_NAME)
+                .dataCatalogOutputs(ModelHelper.buildModelDataCatalogOutputs(DATA_CATALOG_OUTPUT_LIST))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel().getDataCatalogOutputs().size()).isEqualTo(2);
+        assertThat(response.getResourceModel().getDataCatalogOutputs().get(0).getS3Options()).isNotNull();
+        assertThat(response.getResourceModel().getDataCatalogOutputs().get(1).getDatabaseOptions()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
     }
 
 }

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/ListHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/ListHandlerTest.java
@@ -132,6 +132,7 @@ public class ListHandlerTest {
                 .type(TestUtil.JOB_TYPE_RECIPE)
                 .name(TestUtil.JOB_NAME)
                 .outputs(TestUtil.CSV_OUTPUT_VALID_DELIMITER)
+                .dataCatalogOutputs(TestUtil.DATA_CATALOG_OUTPUT_LIST)
                 .build();
         jobs.add(job);
 

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/ReadHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/ReadHandlerTest.java
@@ -46,6 +46,7 @@ public class ReadHandlerTest {
                 .type(TestUtil.JOB_TYPE_PROFILE)
                 .name(TestUtil.JOB_NAME)
                 .outputs(TestUtil.OUTPUTS)
+                .dataCatalogOutputs(TestUtil.DATA_CATALOG_OUTPUT_LIST)
                 .jobSample(TestUtil.customRowsModeJobSample())
                 .timeout(TestUtil.TIMEOUT)
                 .build();
@@ -55,6 +56,7 @@ public class ReadHandlerTest {
                 .name(job.name())
                 .jobSample(job.jobSample())
                 .outputs(TestUtil.OUTPUTS)
+                .dataCatalogOutputs(TestUtil.DATA_CATALOG_OUTPUT_LIST)
                 .timeout(job.timeout())
                 .build();
 

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/TestUtil.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/TestUtil.java
@@ -8,6 +8,9 @@ import software.amazon.awssdk.services.databrew.model.SampleMode;
 import software.amazon.awssdk.services.databrew.model.S3Location;
 import software.amazon.awssdk.services.databrew.model.JobSample;
 import software.amazon.awssdk.services.databrew.model.Output;
+import software.amazon.awssdk.services.databrew.model.DataCatalogOutput;
+import software.amazon.awssdk.services.databrew.model.S3TableOutputOptions;
+import software.amazon.awssdk.services.databrew.model.DatabaseTableOutputOptions;
 
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +51,25 @@ public class TestUtil {
                             .build())
                     .build())
             .build());
+    public static final List<DataCatalogOutput> DATA_CATALOG_OUTPUT_LIST = ImmutableList.of(
+            DataCatalogOutput.builder()
+                    .databaseName("database-name")
+                    .tableName("table-name")
+                    .s3Options(S3TableOutputOptions.builder().location(S3_LOCATION).build())
+                    .build(),
+            DataCatalogOutput.builder()
+                    .databaseName("database-name")
+                    .tableName("table-name")
+                    .databaseOptions(DatabaseTableOutputOptions.builder().tempDirectory(S3_LOCATION).tableName("table-name").build())
+                    .build()
+            );
+    public static final List<DataCatalogOutput> INVALID_DATA_CATALOG_OUTPUT_LIST = ImmutableList.of(
+            DataCatalogOutput.builder()
+                    .databaseName("database-name")
+                    .tableName("table-name")
+                    .s3Options(S3TableOutputOptions.builder().build())
+                    .build()
+    );
     public static final Map<String, String> sampleTags() {
         Map<String, String> tagMap = new HashMap<>();
         tagMap.put("test1Key", "test1Value");

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/UpdateHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/UpdateHandlerTest.java
@@ -498,4 +498,38 @@ public class UpdateHandlerTest {
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
     }
 
+    @Test
+    public void handleRequest_SuccessfulUpdate_RecipeJob_ValidDataCatalogOutput() {
+        final UpdateHandler handler = new UpdateHandler();
+        final UpdateRecipeJobResponse updateRecipeJobResponse = UpdateRecipeJobResponse.builder().build();
+        doReturn(updateRecipeJobResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_RECIPE)
+                .name(TestUtil.JOB_NAME)
+                .dataCatalogOutputs(ModelHelper.buildModelDataCatalogOutputs(TestUtil.DATA_CATALOG_OUTPUT_LIST))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel().getDataCatalogOutputs().size()).isEqualTo(2);
+        assertThat(response.getResourceModel().getDataCatalogOutputs().get(0).getS3Options()).isNotNull();
+        assertThat(response.getResourceModel().getDataCatalogOutputs().get(1).getDatabaseOptions()).isNotNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
 }

--- a/aws-databrew-project/pom.xml
+++ b/aws-databrew-project/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.31</version>
+            <version>2.16.93</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-recipe/aws-databrew-recipe.json
+++ b/aws-databrew-recipe/aws-databrew-recipe.json
@@ -123,6 +123,9 @@
           "anyOf": [
             {
               "$ref": "#/definitions/RecipeParameters"
+            },
+            {
+              "$ref": "#/definitions/ParameterMap"
             }
           ]
         }
@@ -496,6 +499,15 @@
             }
           ],
           "additionalProperties": false
+        }
+      }
+    },
+    "ParameterMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[A-Za-z0-9]{1,128}$": {
+          "type": "string"
         }
       }
     },

--- a/aws-databrew-recipe/pom.xml
+++ b/aws-databrew-recipe/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.31</version>
+            <version>2.16.93</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-recipe/src/main/java/software/amazon/databrew/recipe/ModelHelper.java
+++ b/aws-databrew-recipe/src/main/java/software/amazon/databrew/recipe/ModelHelper.java
@@ -63,10 +63,9 @@ public class ModelHelper {
                 if (tempMap != null) {
                     tempMap.forEach((key, value) -> parametersMap.put(Character.toUpperCase(key.charAt(0)) + key.substring(1), value));
                 }
-                RecipeParameters recipeParameters = mapper.convertValue(parametersMap, RecipeParameters.class);
                 Action modelStepAction = Action.builder()
                         .operation(recipeStep.action().operation())
-                        .parameters(recipeParameters)
+                        .parameters(parametersMap)
                         .build();
 
                 List<software.amazon.databrew.recipe.ConditionExpression> modelConditions = new ArrayList<>();
@@ -97,7 +96,7 @@ public class ModelHelper {
         if (modelRecipeSteps != null) {
             modelRecipeSteps.forEach(step -> {
                 Action modelRecipeAction = step.getAction();
-                RecipeParameters parameters = modelRecipeAction.getParameters();
+                Object parameters = modelRecipeAction.getParameters();
                 ObjectMapper m = new ObjectMapper();
                 Map<String, String> tempMap = m.convertValue(parameters, new TypeReference<Map<String, String>>() {
                 });

--- a/aws-databrew-recipe/src/test/java/software/amazon/databrew/recipe/TestUtil.java
+++ b/aws-databrew-recipe/src/test/java/software/amazon/databrew/recipe/TestUtil.java
@@ -15,10 +15,24 @@ public class TestUtil {
     public static final String INVALID_RECIPE_NAME = "invalid-recipe-test";
     public static final Action STEP_ACTION = Action.builder()
             .operation("REMOVE_VALUES")
+            .parameters(new HashMap<String,String>() {{
+                put("sourceColumn", "source");
+                put("pattern", "pattern");
+                put("targetColumn", "target");
+                put("fromTimeZone", "UTC-07:00");
+                put("FromTimeZone", "UTC-07:00");
+                put("toTimeZone", "Africa/Accra");
+                put("ToTimeZone", "Africa/Accra");
+                put("FunctionStepType", "CONVERT_TIMEZONE");
+            }})
+            .build();
+    public static final Action STEP_ACTION_RECIPE_PARAMETERS = Action.builder()
+            .operation("REMOVE_VALUES")
             .parameters(RecipeParameters.builder()
                     .sourceColumn("source")
                     .pattern("pattern")
                     .targetColumn("target")
+                    .dateTimeFormat("yyyy-mm-dd")
                     .build())
             .build();
     public static final List<ConditionExpression> CONDITIONS = ImmutableList.of(software.amazon.databrew.recipe.ConditionExpression.builder()
@@ -34,11 +48,19 @@ public class TestUtil {
     public static final List<RecipeStep> RECIPE_STEPS = ImmutableList.of(software.amazon.databrew.recipe.RecipeStep.builder()
             .action(STEP_ACTION)
             .conditionExpressions(CONDITIONS)
-            .build());
+            .build(),
+            software.amazon.databrew.recipe.RecipeStep.builder()
+                    .action(STEP_ACTION_RECIPE_PARAMETERS)
+                    .conditionExpressions(CONDITIONS)
+                    .build());
     public static final List<RecipeStep> INVALID_RECIPE_STEPS = ImmutableList.of(software.amazon.databrew.recipe.RecipeStep.builder()
             .action(STEP_ACTION)
             .conditionExpressions(INVALID_CONDITIONS)
-            .build());
+            .build(),
+            software.amazon.databrew.recipe.RecipeStep.builder()
+                    .action(STEP_ACTION_RECIPE_PARAMETERS)
+                    .conditionExpressions(INVALID_CONDITIONS)
+                    .build());
     public static final Map<String, String> sampleTags() {
         Map<String, String> tagMap = new HashMap<>();
         tagMap.put("test1Key", "test1Value");

--- a/aws-databrew-schedule/pom.xml
+++ b/aws-databrew-schedule/pom.xml
@@ -23,13 +23,13 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.16.31</version>
+            <version>2.16.93</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>


### PR DESCRIPTION
*Description of changes:*
This change adds support for the output of job results to the AWS Glue Data Catalog.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
