### PR TITLE
Adds support for  TABLEAUHYPER as newly supported valid values for Output formats for Recipe Jobs

### DIFF
--- a/aws-databrew-dataset/pom.xml
+++ b/aws-databrew-dataset/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.17.3</version>
+            <version>2.17.21</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-job/aws-databrew-job.json
+++ b/aws-databrew-job/aws-databrew-job.json
@@ -183,7 +183,8 @@
             "GLUEPARQUET",
             "AVRO",
             "ORC",
-            "XML"
+            "XML",
+            "TABLEAUHYPER"
           ],
           "type": "string"
         },

--- a/aws-databrew-job/pom.xml
+++ b/aws-databrew-job/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.17.3</version>
+            <version>2.17.21</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/CreateHandlerTest.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/CreateHandlerTest.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.services.databrew.model.ConflictException;
 import software.amazon.awssdk.services.databrew.model.CreateProfileJobResponse;
 import software.amazon.awssdk.services.databrew.model.CreateRecipeJobResponse;
 import software.amazon.awssdk.services.databrew.model.DataBrewException;
+import software.amazon.awssdk.services.databrew.model.OutputFormat;
 import software.amazon.awssdk.services.databrew.model.ProfileConfiguration;
 import software.amazon.awssdk.services.databrew.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.databrew.model.StatisticsConfiguration;
@@ -34,6 +35,7 @@ import static software.amazon.databrew.job.TestUtil.JOB_NAME;
 import static software.amazon.databrew.job.TestUtil.JOB_TYPE_PROFILE;
 import static software.amazon.databrew.job.TestUtil.JOB_TYPE_RECIPE;
 import static software.amazon.databrew.job.TestUtil.TIMEOUT;
+import static software.amazon.databrew.job.TestUtil.TABLEAUHYPER_OUTPUTS;
 import static software.amazon.databrew.job.TestUtil.CSV_OUTPUT_VALID_DELIMITER;
 import static software.amazon.databrew.job.TestUtil.CSV_OUTPUT_INVALID_DELIMITER;
 import static software.amazon.databrew.job.TestUtil.DATASET_STATISTICS_CONFIGURATION;
@@ -665,6 +667,38 @@ public class CreateHandlerTest {
         assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequest_Success_CreateRecipeJob_ValidTABLEAUHYPEROutput() {
+        final CreateHandler handler = new CreateHandler();
+        final CreateRecipeJobResponse createRecipeJobResponse = CreateRecipeJobResponse.builder().build();
+        doReturn(createRecipeJobResponse)
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        final ResourceModel model = ResourceModel.builder()
+                .type(JOB_TYPE_RECIPE)
+                .name(JOB_NAME)
+                .outputs(ModelHelper.buildModelOutputs(TABLEAUHYPER_OUTPUTS))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel().getOutputs().size()).isEqualTo(1);
+        assertThat(response.getResourceModel().getOutputs().get(0).getFormat()).isEqualTo(OutputFormat.TABLEAUHYPER.name());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
     }
 
 }

--- a/aws-databrew-job/src/test/java/software/amazon/databrew/job/TestUtil.java
+++ b/aws-databrew-job/src/test/java/software/amazon/databrew/job/TestUtil.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.services.databrew.model.ColumnSelector;
 import software.amazon.awssdk.services.databrew.model.ColumnStatisticsConfiguration;
 import software.amazon.awssdk.services.databrew.model.CsvOutputOptions;
 import software.amazon.awssdk.services.databrew.model.Job;
+import software.amazon.awssdk.services.databrew.model.OutputFormat;
 import software.amazon.awssdk.services.databrew.model.OutputFormatOptions;
 import software.amazon.awssdk.services.databrew.model.ProfileConfiguration;
 import software.amazon.awssdk.services.databrew.model.SampleMode;
@@ -49,6 +50,10 @@ public class TestUtil {
                             .delimiter(PIPE_CSV_DELIMITER)
                             .build())
                     .build())
+            .build());
+    public static final List<Output> TABLEAUHYPER_OUTPUTS = ImmutableList.of(Output.builder()
+            .location(S3_LOCATION)
+            .format(OutputFormat.TABLEAUHYPER)
             .build());
     public static final List<Output> CSV_OUTPUT_INVALID_DELIMITER= ImmutableList.of(Output.builder()
             .location(S3_LOCATION)

--- a/aws-databrew-project/pom.xml
+++ b/aws-databrew-project/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.17.3</version>
+            <version>2.17.21</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-recipe/pom.xml
+++ b/aws-databrew-recipe/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.17.3</version>
+            <version>2.17.21</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
         <dependency>

--- a/aws-databrew-schedule/pom.xml
+++ b/aws-databrew-schedule/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>databrew</artifactId>
-            <version>2.17.3</version>
+            <version>2.17.21</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
*Description of changes:*
This change adds support for  TABLEAUHYPER as newly supported valid values for Output formats for DataBrew Recipe Jobs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
